### PR TITLE
Add FM mosquito repellent React demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # FMMosquit
-Testing how FM sound keeps mosquitoes away
+
+Simple React demo that plays an FM-modulated tone intended for mosquito repellence.
+Users can start or stop the sound, log feedback, view submissions on a world map,
+and export the collected feedback.
+
+## Features
+- FM synthesis with adjustable modulation index
+- Animated mosquito icon
+- Local feedback logging with export
+- Leaflet map with markers for feedback
+- Twitter sharing link after feedback submission
+- Buy Me A Coffee support link
+
+## Development
+This project has no build step.  All dependencies are loaded from CDNs.
+
+1. Open `index.html` in a browser, or run a small static server:
+   ```bash
+   npx serve .
+   ```
+2. Visit `http://localhost:3000` and interact with the app.
+
+## Deploying to GitHub Pages
+Push this repository to GitHub and enable GitHub Pages for the `main` branch.
+The app will be served from `https://<your-username>.github.io/FMMosquit/`.
+
+## Exported Feedback
+Click **Export Feedback** to download a `feedback.json` file containing
+all feedback entries collected in the current session.
+
+## License
+MIT

--- a/app.js
+++ b/app.js
@@ -1,0 +1,169 @@
+const { useState, useRef, useEffect } = React;
+
+function App() {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [mode, setMode] = useState('safe');
+  const [modIndex, setModIndex] = useState(1000);
+  const [feedbacks, setFeedbacks] = useState([]);
+  const [lastFeedback, setLastFeedback] = useState(null);
+  const audioCtxRef = useRef(null);
+  const carrierRef = useRef(null);
+  const modulatorRef = useRef(null);
+  const modGainRef = useRef(null);
+  const mapRef = useRef(null);
+
+  useEffect(() => {
+    mapRef.current = L.map('map').setView([0, 0], 2);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(mapRef.current);
+  }, []);
+
+  useEffect(() => {
+    if (modGainRef.current) {
+      modGainRef.current.gain.value = modIndex;
+    }
+  }, [modIndex]);
+
+  const startAudio = () => {
+    if (isPlaying) return;
+    const AudioContext = window.AudioContext || window.webkitAudioContext;
+    const audioCtx = new AudioContext();
+    const carrier = audioCtx.createOscillator();
+    const modulator = audioCtx.createOscillator();
+    const modGain = audioCtx.createGain();
+
+    carrier.frequency.value = mode === 'safe' ? 15000 : 19000;
+    modulator.frequency.value = 3000;
+    modGain.gain.value = modIndex;
+
+    modulator.connect(modGain);
+    modGain.connect(carrier.frequency);
+    carrier.connect(audioCtx.destination);
+
+    carrier.start();
+    modulator.start();
+
+    audioCtxRef.current = audioCtx;
+    carrierRef.current = carrier;
+    modulatorRef.current = modulator;
+    modGainRef.current = modGain;
+    setIsPlaying(true);
+  };
+
+  const stopAudio = () => {
+    if (!isPlaying) return;
+    carrierRef.current.stop();
+    modulatorRef.current.stop();
+    audioCtxRef.current.close();
+    setIsPlaying(false);
+  };
+
+  const getCoords = () => {
+    const locale = navigator.language || '';
+    const region = locale.split('-')[1];
+    switch (region) {
+      case 'US':
+        return [37.7749, -122.4194];
+      case 'GB':
+        return [51.5074, -0.1278];
+      case 'FR':
+        return [48.8566, 2.3522];
+      case 'JP':
+        return [35.6762, 139.6503];
+      default:
+        return [0, 0];
+    }
+  };
+
+  const handleFeedback = (result) => {
+    const data = {
+      result,
+      timestamp: new Date().toISOString(),
+      locale: navigator.language || 'Unknown',
+      mode
+    };
+    setFeedbacks((prev) => [...prev, data]);
+    setLastFeedback(result);
+
+    const coords = getCoords();
+    L.marker(coords).addTo(mapRef.current).bindPopup(`${result} @ ${data.timestamp}`);
+  };
+
+  const exportData = () => {
+    const blob = new Blob([JSON.stringify(feedbacks, null, 2)], {
+      type: 'application/json'
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'feedback.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const shareText = (res) => {
+    switch (res) {
+      case 'Effective':
+        return '✅ Effective';
+      case 'Not Effective':
+        return '❌ Not Effective';
+      default:
+        return '🤔 Unclear';
+    }
+  };
+
+  const shareUrl = lastFeedback
+    ? `https://twitter.com/intent/tweet?text=${encodeURIComponent(
+        `Tried the #MosquitoTest2025 🦟\nMy result: ${shareText(lastFeedback)}\nJoin the experiment here: https://yourusername.github.io/FMMosquit`
+      )}`
+    : null;
+
+  return (
+    <div className="app">
+      <h1>FM Mosquito Repellent</h1>
+      <div>
+        <select value={mode} onChange={(e) => setMode(e.target.value)}>
+          <option value="safe">Safe Mode (15–18 kHz)</option>
+          <option value="experiment">Experiment Mode (18–20 kHz)</option>
+        </select>
+      </div>
+      <div>
+        <label>
+          Modulation Index
+          <input
+            type="range"
+            min="0"
+            max="2000"
+            value={modIndex}
+            onChange={(e) => setModIndex(Number(e.target.value))}
+          />
+        </label>
+      </div>
+      <button onClick={startAudio}>Start (Mosquito Repellent ON)</button>
+      <button onClick={stopAudio}>Stop (OFF)</button>
+      <div className={`mosquito ${isPlaying ? 'fly' : ''}`}>
+        <img src="mosquito.svg" alt="mosquito" />
+      </div>
+      <div className="feedback">
+        <button onClick={() => handleFeedback('Effective')}>Effective</button>
+        <button onClick={() => handleFeedback('Not Effective')}>Not Effective</button>
+        <button onClick={() => handleFeedback('Unclear')}>Unclear</button>
+        <button onClick={exportData}>Export Feedback</button>
+        {shareUrl && (
+          <a href={shareUrl} target="_blank" rel="noopener noreferrer">
+            Share on Twitter
+          </a>
+        )}
+      </div>
+      <div id="map"></div>
+      <footer>
+        <a href="https://www.buymeacoffee.com/yourname" target="_blank" rel="noopener noreferrer">
+          ☕ Support the experiment
+        </a>
+      </footer>
+    </div>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/index.html
+++ b/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>FM Mosquito Repellent</title>
+  <link rel="stylesheet" href="style.css" />
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    integrity="sha256-o9N1j7kPpShc9FF0R4xTB5tjVjzPzI0i0XkG6w4i6Gk="
+    crossorigin=""
+  />
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o9N1j7kPpShc9FF0R4xTB5tjVjzPzI0i0XkG6w4i6Gk=" crossorigin=""></script>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="app.js"></script>
+</body>
+</html>

--- a/mosquito.svg
+++ b/mosquito.svg
@@ -1,0 +1,9 @@
+<svg width="60" height="60" viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="30" cy="30" r="5" fill="black" />
+  <line x1="30" y1="15" x2="30" y2="25" stroke="black" />
+  <line x1="30" y1="35" x2="30" y2="45" stroke="black" />
+  <line x1="20" y1="30" x2="10" y2="30" stroke="black" />
+  <line x1="40" y1="30" x2="50" y2="30" stroke="black" />
+  <line x1="25" y1="25" x2="15" y2="15" stroke="black" />
+  <line x1="35" y1="25" x2="45" y2="15" stroke="black" />
+</svg>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,26 @@
+body {
+  font-family: Arial, sans-serif;
+  text-align: center;
+  margin: 0;
+  padding: 0;
+}
+
+.mosquito img {
+  width: 80px;
+  transition: transform 1s ease, opacity 1s ease;
+}
+
+.mosquito.fly img {
+  transform: translateY(-100px);
+  opacity: 0;
+}
+
+footer {
+  margin-top: 2rem;
+}
+
+#map {
+  height: 300px;
+  margin: 1rem auto;
+  width: 90%;
+}


### PR DESCRIPTION
## Summary
- implement React-based FM mosquito repellent with start/stop controls and adjustable modulation index
- add mosquito SVG animation, feedback logging with export, Leaflet map markers, and Twitter sharing
- document setup and GitHub Pages deployment instructions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b14d80c39c83299c2289b402c420c6