### PR TITLE
Add FM mosquito repellent React demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+build/
+
+# misc
+.DS_Store
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # FMMosquit
-Testing how FM sound keeps mosquitoes away
+
+React demo that plays an FM‑modulated tone intended for mosquito repellence.
+Users can start or stop the sound, log feedback, view submissions on a world
+map, and export collected feedback.
+
+## Features
+- FM synthesis with adjustable modulation index
+- Animated mosquito icon
+- Local feedback logging with export
+- Leaflet map with markers for feedback
+- Twitter sharing link after feedback submission
+- Buy Me A Coffee support link
+
+## Development
+This project uses [Create React App](https://create-react-app.dev/).
+
+```bash
+npm install
+npm start       # start development server
+npm run build   # build for production
+```
+
+## Deploying to GitHub Pages
+Deployment is handled by the `gh-pages` package.
+
+```bash
+npm run deploy
+```
+
+The `homepage` field in `package.json` is set to
+`https://kg-ninja.github.io/FMMosquit` so built assets work on GitHub Pages.
+
+## Exported Feedback
+Click **Export Feedback** to download a `feedback.json` file containing all
+feedback entries collected in the current session.
+
+## License
+MIT

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "fmmosquit",
+  "version": "0.1.0",
+  "private": true,
+  "homepage": "https://kg-ninja.github.io/FMMosquit",
+  "dependencies": {
+    "leaflet": "^1.9.4",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-scripts": "5.0.1"
+  },
+  "devDependencies": {
+    "gh-pages": "^6.1.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d build"
+  },
+  "browserslist": {
+    "production": [">0.2%","not dead","not op_mini all"],
+    "development": ["last 1 chrome version","last 1 firefox version","last 1 safari version"]
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>FMMosquit</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,137 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { startFM, stopFM, startJitter, stopJitter } from './audio/fm';
+import MapView from './map/MapView';
+import MosquitoIcon from './components/MosquitoIcon';
+
+const SITE_URL = 'https://kg-ninja.github.io/FMMosquit';
+const BMC_URL = 'https://www.buymeacoffee.com/YOUR_BMC_HANDLE'; // TODO: replace
+
+export default function App() {
+  const [isOn, setIsOn] = useState(false);
+  const [mode, setMode] = useState('safe'); // 'safe' (15–18kHz-ish) or 'experiment'
+  const [feedback, setFeedback] = useState([]); // in-memory JSON
+  const [coords, setCoords] = useState(null);
+  const jitterTimer = useRef(null);
+
+  // ask for location once
+  useEffect(() => {
+    if (!navigator.geolocation) return;
+    navigator.geolocation.getCurrentPosition(
+      (pos) => setCoords({ lat: pos.coords.latitude, lng: pos.coords.longitude }),
+      () => setCoords(null),
+      { enableHighAccuracy: false, timeout: 5000 }
+    );
+  }, []);
+
+  const locale = useMemo(() => navigator.language || 'Unknown', []);
+
+  const onStart = () => {
+    if (isOn) return;
+    if (mode === 'safe') {
+      startFM({ carrierHz: 10000, modHz: 3000, index: 3000 });
+      startJitter({ minModHz: 2500, maxModHz: 3500, minIndex: 2500, maxIndex: 3500, periodMs: 1200 });
+    } else {
+      startFM({ carrierHz: 11000, modHz: 3200, index: 5000 });
+      startJitter({ minModHz: 2200, maxModHz: 5000, minIndex: 3500, maxIndex: 6500, periodMs: 800 });
+    }
+    setIsOn(true);
+  };
+
+  const onStop = () => {
+    stopJitter();
+    stopFM();
+    setIsOn(false);
+  };
+
+  const addFeedback = (result) => {
+    const entry = {
+      result, // 'effective' | 'ineffective' | 'unclear'
+      ts: new Date().toISOString(),
+      locale,
+      mode,
+      coords: coords ? { ...coords } : null
+    };
+    setFeedback((prev) => [...prev, entry]);
+  };
+
+  const exportJSON = () => {
+    const blob = new Blob([JSON.stringify(feedback, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = 'feedback.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const shareOnTwitter = (lastResult) => {
+    const text = encodeURIComponent(
+      `Tried the #MosquitoTest2025 🦟\nMy result: ${lastResult}\n`
+    );
+    const url = encodeURIComponent(SITE_URL);
+    window.open(`https://twitter.com/intent/tweet?text=${text}&url=${url}`, '_blank');
+  };
+
+  useEffect(() => {
+    return () => { stopJitter(); stopFM(); };
+  }, []);
+
+  return (
+    <div className="container">
+      <header>
+        <h1>FMMosquit</h1>
+        <p>FM-modulated high-frequency demo + global feedback map</p>
+      </header>
+
+      <section className="controls">
+        <div className="mode">
+          <label>
+            <input type="radio" name="mode" value="safe"
+              checked={mode==='safe'} onChange={() => setMode('safe')} />
+            Pet-safe mode (≈15–18kHz)
+          </label>
+          <label>
+            <input type="radio" name="mode" value="experiment"
+              checked={mode==='experiment'} onChange={() => setMode('experiment')} />
+            Experiment mode (≈18–20kHz)
+          </label>
+        </div>
+
+        <div className="buttons">
+          {!isOn ? (
+            <button className="primary" onClick={onStart}>Mosquito Repellent ON</button>
+          ) : (
+            <button className="danger" onClick={onStop}>OFF</button>
+          )}
+        </div>
+
+        <div className="mosquitoWrap">
+          <MosquitoIcon active={isOn} />
+        </div>
+      </section>
+
+      <section className="feedback">
+        <h2>Your feedback</h2>
+        <div className="buttons">
+          <button onClick={() => { addFeedback('✅ Effective'); shareOnTwitter('✅ Effective'); }}>Effective</button>
+          <button onClick={() => { addFeedback('❌ Not Effective'); shareOnTwitter('❌ Not Effective'); }}>Not Effective</button>
+          <button onClick={() => { addFeedback('🤔 Unclear'); shareOnTwitter('🤔 Unclear'); }}>Unclear</button>
+        </div>
+        <div className="export">
+          <button onClick={exportJSON}>Export feedback.json</button>
+        </div>
+      </section>
+
+      <section className="map">
+        <h2>Global feedback map</h2>
+        <MapView data={feedback} />
+      </section>
+
+      <footer>
+        <a href={BMC_URL} target="_blank" rel="noreferrer">☕ Support this experiment on BuyMeACoffee</a>
+        <span> • </span>
+        <a href={SITE_URL} target="_blank" rel="noreferrer">{SITE_URL}</a>
+      </footer>
+    </div>
+  );
+}
+

--- a/src/audio/fm.js
+++ b/src/audio/fm.js
@@ -1,0 +1,53 @@
+let ctx = null;
+let carrier = null;
+let mod = null;
+let modGain = null;
+let jitterTimer = null;
+
+export function startFM({ carrierHz = 10000, modHz = 3000, index = 3000 } = {}) {
+  if (!ctx) ctx = new (window.AudioContext || window.webkitAudioContext)();
+
+  carrier = ctx.createOscillator();
+  carrier.type = 'sine';
+  carrier.frequency.value = carrierHz;
+
+  mod = ctx.createOscillator();
+  mod.type = 'sine';
+  mod.frequency.value = modHz;
+
+  modGain = ctx.createGain();
+  modGain.gain.value = index;
+
+  mod.connect(modGain);
+  modGain.connect(carrier.frequency);
+
+  const outGain = ctx.createGain();
+  outGain.gain.value = 0.1; // keep it low for safety
+
+  carrier.connect(outGain).connect(ctx.destination);
+  carrier.start(); mod.start();
+}
+
+export function stopFM() {
+  try { carrier && carrier.stop(); } catch {}
+  try { mod && mod.stop(); } catch {}
+  carrier = null; mod = null; modGain = null;
+}
+
+export function startJitter({ minModHz=2500, maxModHz=3500, minIndex=2500, maxIndex=3500, periodMs=1000 }={}) {
+  stopJitter();
+  jitterTimer = setInterval(() => {
+    if (!mod || !modGain) return;
+    const newF = rand(minModHz, maxModHz);
+    const newI = rand(minIndex, maxIndex);
+    mod.frequency.setTargetAtTime(newF, ctx.currentTime, 0.05);
+    modGain.gain.setTargetAtTime(newI, ctx.currentTime, 0.05);
+  }, periodMs);
+}
+export function stopJitter() {
+  if (jitterTimer) clearInterval(jitterTimer);
+  jitterTimer = null;
+}
+
+function rand(min, max) { return Math.random() * (max - min) + min; }
+

--- a/src/components/MosquitoIcon.jsx
+++ b/src/components/MosquitoIcon.jsx
@@ -1,0 +1,18 @@
+export default function MosquitoIcon({ active }) {
+  return (
+    <svg
+      className={`mosquito ${active ? 'active' : ''}`}
+      width="80" height="80" viewBox="0 0 80 80" aria-label="mosquito"
+    >
+      <circle cx="40" cy="40" r="8" fill="#333" />
+      <ellipse cx="30" cy="40" rx="10" ry="4" fill="#444" />
+      <ellipse cx="50" cy="40" rx="10" ry="4" fill="#444" />
+      <line x1="40" y1="32" x2="40" y2="18" stroke="#222" strokeWidth="2"/>
+      <line x1="35" y1="48" x2="25" y2="60" stroke="#555" strokeWidth="2"/>
+      <line x1="45" y1="48" x2="55" y2="60" stroke="#555" strokeWidth="2"/>
+      <line x1="42" y1="36" x2="60" y2="30" stroke="#222" strokeWidth="1"/>
+      <line x1="38" y1="36" x2="20" y2="30" stroke="#222" strokeWidth="1"/>
+    </svg>
+  );
+}
+

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,7 @@
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+const container = document.getElementById('root');
+createRoot(container).render(<App />);
+

--- a/src/map/MapView.jsx
+++ b/src/map/MapView.jsx
@@ -1,0 +1,44 @@
+import { useEffect, useRef } from 'react';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+
+// Fix default icon paths in bundlers (CRA)
+import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png';
+import markerIcon from 'leaflet/dist/images/marker-icon.png';
+import markerShadow from 'leaflet/dist/images/marker-shadow.png';
+delete L.Icon.Default.prototype._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: markerIcon2x,
+  iconUrl: markerIcon,
+  shadowUrl: markerShadow,
+});
+
+export default function MapView({ data }) {
+  const mapRef = useRef(null);
+  const layerRef = useRef(null);
+
+  useEffect(() => {
+    if (!mapRef.current) {
+      mapRef.current = L.map('map', { center: [20, 0], zoom: 2, worldCopyJump: true });
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 19,
+        attribution: '&copy; OpenStreetMap contributors'
+      }).addTo(mapRef.current);
+      layerRef.current = L.layerGroup().addTo(mapRef.current);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!layerRef.current) return;
+    layerRef.current.clearLayers();
+    data.forEach((d) => {
+      if (!d.coords) return; // skip if no coords
+      const { lat, lng } = d.coords;
+      const m = L.marker([lat, lng]).bindPopup(`${d.result}<br/>${d.ts}<br/>${d.locale}<br/>${d.mode}`);
+      m.addTo(layerRef.current);
+    });
+  }, [data]);
+
+  return <div id="map" style={{ height: 320, width: '100%', borderRadius: 12 }} />;
+}
+

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,19 @@
+:root { --bg:#0b1020; --fg:#e8f0ff; --muted:#a6b0c0; --accent:#8ee; }
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--fg);font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial}
+.container{max-width:960px;margin:0 auto;padding:20px}
+header h1{margin:8px 0 0}
+header p{margin:4px 0 16px;color:var(--muted)}
+.controls{display:grid;gap:12px;margin-bottom:16px}
+.mode label{margin-right:16px}
+.buttons{display:flex;gap:10px;flex-wrap:wrap}
+button{padding:10px 14px;border:0;border-radius:10px;cursor:pointer}
+button.primary{background:#1e90ff;color:white}
+button.danger{background:#f05;color:white}
+.mosquitoWrap{height:90px;display:flex;align-items:center}
+.mosquito{transition:transform 0.8s ease, opacity 0.8s ease}
+.mosquito.active{transform:translateX(220px) translateY(-40px) rotate(15deg); opacity:0.15}
+.map h2, .feedback h2{margin:16px 0 8px}
+footer{margin-top:20px;color:var(--muted)}
+footer a{color:var(--accent);text-decoration:none}
+


### PR DESCRIPTION
## Summary
- rebuild with Create React App and React 18 `createRoot`
- play FM-modulated tone and animate mosquito when active
- log feedback, plot Leaflet markers, and configure GitHub Pages deployment

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/gh-pages)*
- `npm start` *(fails: react-scripts: not found)*
- `npm test` *(fails: react-scripts: not found)*
- `npm run build` *(fails: react-scripts: not found)*
- `npm run deploy` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b14d80c39c83299c2289b402c420c6